### PR TITLE
[BGF] fix a memory leak in FUChatActivity due to anonymous inner class.

### DIFF
--- a/Agora-Video-With-FaceUnity-Android/app/src/main/java/io/agora/rtcwithfu/activities/FUChatActivity.java
+++ b/Agora-Video-With-FaceUnity-Android/app/src/main/java/io/agora/rtcwithfu/activities/FUChatActivity.java
@@ -207,6 +207,8 @@ public class FUChatActivity extends RtcBasedActivity implements RtcEngineEventHa
             e.printStackTrace();
         }
         mVideoManager.stopCapture();
+        mVideoManager.setCameraStateListener(null);
+        mFURenderer.setOnTrackStatusChangedListener(null);
         rtcEngine().leaveChannel();
         super.finish();
     }


### PR DESCRIPTION
`mVideoManager.setCameraStateListener()` and `mFURenderer.setOnTrackStatusChangedListener()` cause the problem.
Anonymous inner class will keep a reference to its outer class.
Basically we have two options to avoid memory leak:
1. removing listeners when exit. 
2. Using weak references.

A better solution is to clear all listeners on the related SDK level in appropriate lifecycle.